### PR TITLE
Add automation plan and basic framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+automation.js
+automation.test.js
+package-lock.json

--- a/HANDLINGSPLAN.md
+++ b/HANDLINGSPLAN.md
@@ -1,0 +1,30 @@
+# Handlingsplan for oppgave/steghåndtering
+
+Dette dokumentet beskriver en enkel struktur for automatiserte oppgaver bestående av steg og handlinger. Strukturen er inspirert av tidligere diskusjon om `task → step → actions` og gir mulighet til å navigere, klikke, fylle inn verdier og hente ut data.
+
+## Struktur
+
+- **Task** – inneholder en liste av steg som utføres sekvensielt.
+- **Step** – hvert steg består av en liste av handlinger.
+- **Action** – konkrete operasjoner som `navigate`, `click`, `fill` og `extract`.
+- **MockPage** – enkel implementasjon som logger handlingene og kan simulere uttrekk av data fra et definert DOM‑lignende objekt.
+
+## Eksempel
+
+```ts
+const actions: Action[] = [
+  { type: 'navigate', url: 'https://example.com' },
+  { type: 'click', selector: '#open' },
+  { type: 'fill', selector: '#search', value: 'shoes' },
+  {
+    type: 'extract',
+    container: '.product-card',
+    fields: [
+      { key: 'title', selector: '.title' },
+      { key: 'price', selector: '.price' },
+    ],
+  },
+];
+```
+
+Se `automation.ts` for implementasjonen og `automation.test.ts` for enkle tester som verifiserer at strukturen fungerer som forventet.

--- a/automation.test.ts
+++ b/automation.test.ts
@@ -1,0 +1,51 @@
+declare function require(name: string): any;
+declare const console: any;
+const assert = require('assert');
+import { Action, Step, Task, MockPage } from './automation';
+
+const dom = {
+  '.product-card': [
+    {
+      '.title': 'Product 1',
+      '.price': '$10',
+    },
+    {
+      '.title': 'Product 2',
+      '.price': '$20',
+    },
+  ],
+};
+
+const actions: Action[] = [
+  { type: 'navigate', url: 'https://example.com' },
+  { type: 'click', selector: '#open' },
+  { type: 'fill', selector: '#search', value: 'shoes' },
+  {
+    type: 'extract',
+    container: '.product-card',
+    fields: [
+      { key: 'title', selector: '.title' },
+      { key: 'price', selector: '.price' },
+    ],
+  },
+];
+
+const step = new Step(actions);
+const task = new Task([step]);
+const page = new MockPage(dom);
+
+(async () => {
+  await task.run(page);
+  assert.deepStrictEqual(page.logs, [
+    'navigate:https://example.com',
+    'click:#open',
+    'fill:#search=shoes',
+    'extract:.product-card',
+  ]);
+  assert.deepStrictEqual(page.filled, { '#search': 'shoes' });
+  assert.deepStrictEqual(page.lastExtract, [
+    { title: 'Product 1', price: '$10' },
+    { title: 'Product 2', price: '$20' },
+  ]);
+  console.log('All tests passed');
+})();

--- a/automation.ts
+++ b/automation.ts
@@ -1,0 +1,64 @@
+export type Action =
+  | { type: 'navigate'; url: string }
+  | { type: 'click'; selector: string }
+  | { type: 'fill'; selector: string; value: string }
+  | {
+      type: 'extract';
+      container: string;
+      fields: { key: string; selector: string }[];
+    };
+
+export class Step {
+  constructor(public actions: Action[]) {}
+  async run(page: MockPage): Promise<void> {
+    for (const action of this.actions) {
+      await page.execute(action);
+    }
+  }
+}
+
+export class Task {
+  constructor(public steps: Step[]) {}
+  async run(page: MockPage): Promise<void> {
+    for (const step of this.steps) {
+      await step.run(page);
+    }
+  }
+}
+
+export class MockPage {
+  logs: string[] = [];
+  filled: Record<string, string> = {};
+  lastExtract: any[] = [];
+  constructor(public dom: Record<string, any[]> = {}) {}
+
+  async execute(action: Action): Promise<void> {
+    switch (action.type) {
+      case 'navigate':
+        this.logs.push(`navigate:${action.url}`);
+        break;
+      case 'click':
+        this.logs.push(`click:${action.selector}`);
+        break;
+      case 'fill':
+        this.logs.push(`fill:${action.selector}=${action.value}`);
+        this.filled[action.selector] = action.value;
+        break;
+      case 'extract':
+        this.logs.push(`extract:${action.container}`);
+        this.lastExtract = this.extract(action.container, action.fields);
+        break;
+    }
+  }
+
+  extract(container: string, fields: { key: string; selector: string }[]): any[] {
+    const items = this.dom[container] || [];
+    return items.map((item) => {
+      const result: Record<string, any> = {};
+      for (const f of fields) {
+        result[f.key] = item[f.selector];
+      }
+      return result;
+    });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "typescript",
   "version": "0.0.0",
   "private": true,
+  "scripts": {
+    "test": "npx tsc -p tsconfig.test.json && node dist/automation.test.js"
+  },
   "dependencies": {
     "howler": "^2.2.4",
     "seedrandom": "3.0.5"

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -4,5 +4,6 @@
     "module": "commonjs",
     "lib": ["es2019"],
     "outDir": "dist"
-  }
+  },
+  "files": ["automation.ts", "automation.test.ts"]
 }


### PR DESCRIPTION
## Summary
- add a simple handlingsplan for a task/step/action system
- create automation framework with Task, Step and MockPage
- provide tests showing usage of the framework
- add tsconfig for tests and update package.json scripts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683cdb1f94b883338cbb393a6ab33bd3